### PR TITLE
Pass along options to wrap-ansi

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function neatFrame(str, options) {
 	const padding = `  │${' '.repeat(contentWidth)}│`;
 	const verticalBar = '─'.repeat(contentWidth);
 
-	const wrapAnsiOption = mergeOptions(defaultWrapAnsiOption, options)
+	const wrapAnsiOption = mergeOptions(defaultWrapAnsiOption, options);
 
 	return `  ┌${verticalBar}┐
 ${padding}

--- a/index.js
+++ b/index.js
@@ -4,18 +4,11 @@ const inspectWithKind = require('inspect-with-kind');
 const termSize = require('term-size');
 const stringWidth = require('string-width');
 const wrapAnsi = require('wrap-ansi');
+const mergeOptions = require('merge-options');
 
-const wrapAnsiOption = {hard: true};
+const defaultWrapAnsiOption = {hard: true};
 
-module.exports = function neatFrame(...args) {
-	const argLen = args.length;
-
-	if (argLen !== 1) {
-		throw new RangeError(`Expected 1 argument (string), but got ${argLen || 'no'} arguments instead.`);
-	}
-
-	const [str] = args;
-
+module.exports = function neatFrame(str, options) {
 	if (typeof str !== 'string') {
 		throw new TypeError(`Expected a string to be framed with box-drawing characters, but got ${
 			inspectWithKind(str)
@@ -27,6 +20,8 @@ module.exports = function neatFrame(...args) {
 
 	const padding = `  │${' '.repeat(contentWidth)}│`;
 	const verticalBar = '─'.repeat(contentWidth);
+
+	const wrapAnsiOption = mergeOptions(defaultWrapAnsiOption, options)
 
 	return `  ┌${verticalBar}┐
 ${padding}

--- a/package-lock.json
+++ b/package-lock.json
@@ -977,6 +977,11 @@
 				"path-is-inside": "^1.0.1"
 			}
 		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "http://localhost:4873/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -1133,6 +1138,14 @@
 				"yallist": "^2.1.2"
 			}
 		},
+		"merge-options": {
+			"version": "1.0.1",
+			"resolved": "http://localhost:4873/merge-options/-/merge-options-1.0.1.tgz",
+			"integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+			"requires": {
+				"is-plain-obj": "^1.1"
+			}
+		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -1232,6 +1245,7 @@
 					"version": "0.1.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -1553,7 +1567,8 @@
 				"is-buffer": {
 					"version": "1.1.6",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
@@ -1637,6 +1652,7 @@
 					"version": "3.2.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -1683,7 +1699,8 @@
 				"longest": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
@@ -1949,7 +1966,8 @@
 				"repeat-string": {
 					"version": "1.6.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"require-directory": {
 					"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	],
 	"dependencies": {
 		"inspect-with-kind": "^1.0.5",
+		"merge-options": "^1.0.1",
 		"string-width": "^2.1.1",
 		"term-size": "^1.2.0",
 		"wrap-ansi": "^4.0.0"

--- a/test.js
+++ b/test.js
@@ -46,18 +46,6 @@ test('neatFrame()', t => {
 	);
 
 	t.throws(
-		() => neatFrame(),
-		/^RangeError.*Expected 1 argument \(string\), but got no arguments instead\./u,
-		'should throw an error when it takes no arguments.'
-	);
-
-	t.throws(
-		() => neatFrame('a', 'b'),
-		/^RangeError.*Expected 1 argument \(string\), but got 2 arguments instead\./u,
-		'should throw an error when it takes too many arguments.'
-	);
-
-	t.throws(
 		() => neatFrame(Buffer.from('a')),
 		/TypeError.*Expected a string to be framed with box-drawing characters, but got <Buffer 61>\./u,
 		'should throw an error when it takes a non-string argument.'


### PR DESCRIPTION
I needed this so I could prevent it from trimming indentation on a JSON string